### PR TITLE
Sets partition size

### DIFF
--- a/main.go
+++ b/main.go
@@ -163,6 +163,7 @@ func main() {
 				"-no-snapshot",
 				"-wipe-data",
 				"-partition-size", "2048",
+				"-camera-back","emulated",
 				"-gpu", "swiftshader_indirect"}, startCustomFlags...)...),
 			func(cmd *command.Model) func() (string, error) { // need to start the emlator as a detached process
 				return func() (string, error) {

--- a/main.go
+++ b/main.go
@@ -162,6 +162,7 @@ func main() {
 				"-netdelay", "none",
 				"-no-snapshot",
 				"-wipe-data",
+				"-partition-size", "2048",
 				"-gpu", "swiftshader_indirect"}, startCustomFlags...)...),
 			func(cmd *command.Model) func() (string, error) { // need to start the emlator as a detached process
 				return func() (string, error) {

--- a/step.yml
+++ b/step.yml
@@ -93,7 +93,7 @@ inputs:
       summary: Flags used when running the command to create the emulator.
       description: Flags used when running the command to create the emulator.
       is_required: false
-  - start_command_flags: "-camera-back none -camera-front none"
+  - start_command_flags: "-camera-back emulated -camera-front none"
     opts:
       category: Debug
       title: "Start AVD command flags"


### PR DESCRIPTION
The default AVD device's setting does not have enough capacity to execute our tests.

This PR updates a forked version of the **steps-avd-manager** library to include the required parameter.

Note: It would be nice to make the "partition size" a Bitrise's parameter.

## Important
This changes will be used in our Bitrise flow with a reference to the `v1` branch, so please do not remove the branch.
 