### PR TITLE
Support back camera on emulator

### DIFF
--- a/main.go
+++ b/main.go
@@ -163,6 +163,7 @@ func main() {
 				"-no-snapshot",
 				"-wipe-data",
 				"-partition-size", "2048",
+				"-camera-back","emulated",
 				"-gpu", "swiftshader_indirect"}, startCustomFlags...)...),
 			func(cmd *command.Model) func() (string, error) { // need to start the emlator as a detached process
 				return func() (string, error) {

--- a/step.yml
+++ b/step.yml
@@ -93,7 +93,7 @@ inputs:
       summary: Flags used when running the command to create the emulator.
       description: Flags used when running the command to create the emulator.
       is_required: false
-  - start_command_flags: "-camera-back none -camera-front none"
+  - start_command_flags: "-camera-back emulated -camera-front none"
     opts:
       category: Debug
       title: "Start AVD command flags"


### PR DESCRIPTION
The official Bitrise's step for android emulator does not have a section to configure the camera.

This PR updates the main.go file and always starts the android emulator with camera support.